### PR TITLE
fixed cryptography version at 1.8.2 as dropped multibackend support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
-        'cryptography>=1.2.3',
+        'cryptography==1.8.2',
         'keylib>=0.0.2',
         'requests>=2.9.1',
         'utilitybelt>=0.2.6'


### PR DESCRIPTION
[Cryptography dropped support for multibackend in 1.9](https://github.com/pyca/cryptography/blob/b90e8d81a3814331fafc732fa0f2d44f5f71dfbb/CHANGELOG.rst#19---2017-05-29)