### PR TITLE
do not use the deprecated Backend and Multibackend classes from cryptography

### DIFF
--- a/jsontokens/key_loading.py
+++ b/jsontokens/key_loading.py
@@ -10,8 +10,6 @@
 import traceback
 
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.backends.openssl.backend import Backend
-from cryptography.hazmat.backends.multibackend import MultiBackend
 from cryptography.hazmat.primitives.serialization import (
     load_der_private_key, load_pem_private_key,
     load_der_public_key, load_pem_public_key
@@ -44,11 +42,9 @@ class InvalidPublicKeyError(InvalidKeyError):
 def load_signing_key(signing_key, crypto_backend=default_backend()):
     """ Optional: crypto backend object from the "cryptography" python library
     """
-    if not isinstance(crypto_backend, (Backend, MultiBackend)):
-        raise ValueError('backend must be a valid Backend object')
-
     if isinstance(signing_key, EllipticCurvePrivateKey):
         return signing_key
+
     elif isinstance(signing_key, (str, unicode)):
         invalid_strings = [b'-----BEGIN PUBLIC KEY-----']
         invalid_string_matches = [
@@ -90,11 +86,9 @@ def load_signing_key(signing_key, crypto_backend=default_backend()):
 def load_verifying_key(verifying_key, crypto_backend=default_backend()):
     """ Optional: crypto backend object from the "cryptography" python library
     """
-    if not isinstance(crypto_backend, (Backend, MultiBackend)):
-        raise ValueError('backend must be a valid Backend object')
-
     if isinstance(verifying_key, EllipticCurvePublicKey):
         return verifying_key
+
     elif isinstance(verifying_key, (str, unicode)):
         if is_hex(verifying_key):
             try:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
-        'cryptography>=1.2.3',
+        'cryptography>=1.9',
         'keylib>=0.0.2',
         'requests>=2.9.1',
         'utilitybelt>=0.2.6'


### PR DESCRIPTION
This makes us compatible with cryptography >= 1.9